### PR TITLE
drivers: wireless: Fix mtu info for gs2200m

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -3533,6 +3533,11 @@ FAR void *gs2200m_register(FAR const char *devpath,
       goto errout;
     }
 
+  /* Set d_pktsize and d_llhdrlen to show mtu info correctly */
+
+  dev->net_dev.d_pktsize  = MAX_PKT_LEN;
+  dev->net_dev.d_llhdrlen = 0;
+
   return dev;
 
 errout:


### PR DESCRIPTION
## Summary

- I noticed that mtu info with ifconfig shows incorrect size.
- This commit fixes this issue.

## Impact

- None

## Testing

- Tested with spresense:wifi_smp
